### PR TITLE
Add uaa_client to provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ website/node_modules
 *.iml
 *.test
 *.iml
+terraform-provider-uaa
+.env.json
 
 website/vendor
 

--- a/uaa/data_source_cf_client.go
+++ b/uaa/data_source_cf_client.go
@@ -1,0 +1,134 @@
+package uaa
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-uaa/uaa/uaaapi"
+)
+
+func dataSourceClient() *schema.Resource {
+
+	return &schema.Resource{
+
+		Read: dataSourceClientRead,
+
+		Schema: map[string]*schema.Schema{
+			"client_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"authorized_grant_types": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      resourceStringHash,
+			},
+			"redirect_uri": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      resourceStringHash,
+			},
+			"scope": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      resourceStringHash,
+			},
+			"resource_ids": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      resourceStringHash,
+			},
+			"authorities": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      resourceStringHash,
+			},
+			"autoapprove": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      resourceStringHash,
+			},
+			"access_token_validity": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"refresh_token_validity": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"allowedproviders": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      resourceStringHash,
+			},
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"token_salt": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"createdwith": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"approvals_deleted": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"required_user_groups": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      resourceStringHash,
+			},
+		},
+	}
+}
+
+func dataSourceClientRead(d *schema.ResourceData, meta interface{}) (err error) {
+
+	session := meta.(*uaaapi.Session)
+	if session == nil {
+		return fmt.Errorf("client is nil")
+	}
+
+	um := session.ClientManager()
+
+	var (
+		id     string
+		client uaaapi.UAAClient
+	)
+
+	id = d.Get("client_id").(string)
+	client, err = um.FindByClientID(id)
+	if err != nil {
+		return
+	}
+
+	d.SetId(client.ClientID)
+	d.Set("scope", schema.NewSet(resourceStringHash, toInterface(client.Scope)))
+	d.Set("authorities", schema.NewSet(resourceStringHash, toInterface(client.Authorities)))
+	d.Set("resource_ids", schema.NewSet(resourceStringHash, toInterface(client.ResourceIds)))
+	d.Set("authorized_grant_types", schema.NewSet(resourceStringHash, toInterface(client.AuthorizedGrantTypes)))
+	d.Set("redirect_uri", schema.NewSet(resourceStringHash, toInterface(client.RedirectURI)))
+	d.Set("autoapprove", schema.NewSet(resourceStringHash, toInterface(client.Autoapprove)))
+	d.Set("allowedproviders", schema.NewSet(resourceStringHash, toInterface(client.Allowedproviders)))
+	d.Set("required_user_groups", schema.NewSet(resourceStringHash, toInterface(client.RequiredUserGroups)))
+	d.Set("client_id", client.ClientID)
+	d.Set("access_token_validity", client.AccessTokenValidity)
+	d.Set("refresh_token_validity", client.RefreshTokenValidity)
+	d.Set("name", client.Name)
+	d.Set("token_salt", client.TokenSalt)
+	d.Set("createdwith", client.CreatedWith)
+	d.Set("approvals_deleted", client.ApprovalsDeleted)
+	return
+}

--- a/uaa/data_source_cf_client_test.go
+++ b/uaa/data_source_cf_client_test.go
@@ -1,0 +1,99 @@
+package uaa
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/terraform-providers/terraform-provider-uaa/uaa/uaaapi"
+	"regexp"
+)
+
+const clientDataResource = `
+data "uaa_client" "admin-client" {
+    client_id = "admin"
+}
+`
+
+const clientDataResourceNotFound = `
+data "uaa_client" "admin-client2" {
+    client_id = "does-not-exist"
+}
+`
+
+func TestAccDataSourceClient_normal(t *testing.T) {
+	ref := "data.uaa_client.admin-client"
+	resource.Test(t,
+		resource.TestCase{
+			PreCheck:  func() { testAccPreCheck(t) },
+			Providers: testAccProviders,
+			Steps: []resource.TestStep{
+				resource.TestStep{
+					Config: clientDataResource,
+					Check: resource.ComposeTestCheckFunc(
+						checkDataSourceClientExists(ref),
+						resource.TestCheckResourceAttr(ref, "client_id", "admin"),
+						testCheckResourceSet(ref, "authorities", []string{
+							"clients.read",
+							"password.write",
+							"clients.secret",
+							"clients.write",
+							"uaa.admin",
+							"scim.write",
+							"scim.read",
+						}),
+					),
+				},
+			},
+		})
+}
+
+func TestAccDataSourceClient_notfound(t *testing.T) {
+	resource.Test(t,
+		resource.TestCase{
+			PreCheck:  func() { testAccPreCheck(t) },
+			Providers: testAccProviders,
+			Steps: []resource.TestStep{
+				resource.TestStep{
+					Config:      clientDataResourceNotFound,
+					ExpectError: regexp.MustCompile(".*Client does-not-exist not found.*"),
+				},
+			},
+		})
+}
+
+func checkDataSourceClientExists(resource string) resource.TestCheckFunc {
+
+	return func(s *terraform.State) error {
+
+		session := testAccProvider.Meta().(*uaaapi.Session)
+
+		rs, ok := s.RootModule().Resources[resource]
+		if !ok {
+			return fmt.Errorf("client '%s' not found in terraform state", resource)
+		}
+
+		session.Log.DebugMessage(
+			"terraform state for resource '%s': %# v",
+			resource, rs)
+
+		id := rs.Primary.ID
+		client_id := rs.Primary.Attributes["client_id"]
+
+		var (
+			err    error
+			client uaaapi.UAAClient
+		)
+
+		client, err = session.ClientManager().FindByClientID(client_id)
+		if err != nil {
+			return err
+		}
+		if err := assertSame(id, client.ClientID); err != nil {
+			return err
+		}
+
+		return nil
+	}
+}

--- a/uaa/provider.go
+++ b/uaa/provider.go
@@ -43,11 +43,13 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
-			"uaa_user": dataSourceUser(),
+			"uaa_user":   dataSourceUser(),
+			"uaa_client": dataSourceClient(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-			"uaa_user": resourceUser(),
+			"uaa_user":   resourceUser(),
+			"uaa_client": resourceClient(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/uaa/resource_cf_client.go
+++ b/uaa/resource_cf_client.go
@@ -1,0 +1,283 @@
+package uaa
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-uaa/uaa/uaaapi"
+)
+
+func resourceClient() *schema.Resource {
+
+	return &schema.Resource{
+		Create: resourceClientCreate,
+		Read:   resourceClientRead,
+		Update: resourceClientUpdate,
+		Delete: resourceClientDelete,
+
+		Schema: map[string]*schema.Schema{
+			"client_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"client_secret": &schema.Schema{
+				Type:      schema.TypeString,
+				Optional:  true,
+				Sensitive: true,
+			},
+			"authorized_grant_types": &schema.Schema{
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      resourceStringHash,
+			},
+			"redirect_uri": &schema.Schema{
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      resourceStringHash,
+			},
+			"scope": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      resourceStringHash,
+			},
+			"resource_ids": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      resourceStringHash,
+			},
+			"authorities": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      resourceStringHash,
+			},
+			"autoapprove": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      resourceStringHash,
+			},
+			"access_token_validity": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"refresh_token_validity": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"allowedproviders": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      resourceStringHash,
+			},
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"token_salt": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"createdwith": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"approvals_deleted": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"required_user_groups": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      resourceStringHash,
+			},
+		},
+	}
+}
+
+func resourceClientCreate(d *schema.ResourceData, meta interface{}) error {
+
+	session := meta.(*uaaapi.Session)
+	if session == nil {
+		return fmt.Errorf("client is nil")
+	}
+
+	client := uaaapi.UAAClient{
+		ClientID:             d.Get("client_id").(string),
+		ClientSecret:         d.Get("client_secret").(string),
+		AuthorizedGrantTypes: toStrings(d.Get("authorized_grant_types")),
+		RedirectURI:          toStrings(d.Get("redirect_uri")),
+		ResourceIds:          toStrings(d.Get("resource_ids")),
+		Authorities:          toStrings(d.Get("authorities")),
+		Autoapprove:          toStrings(d.Get("autoapprove")),
+		Allowedproviders:     toStrings(d.Get("allowedproviders")),
+		RequiredUserGroups:   toStrings(d.Get("required_user_groups")),
+		Scope:                toStrings(d.Get("scope")),
+		AccessTokenValidity:  d.Get("access_token_validity").(int),
+		RefreshTokenValidity: d.Get("refresh_token_validity").(int),
+		Name:                 d.Get("name").(string),
+		TokenSalt:            d.Get("token_salt").(string),
+		CreatedWith:          d.Get("createdwith").(string),
+		ApprovalsDeleted:     d.Get("approvals_deleted").(bool),
+	}
+
+	um := session.ClientManager()
+	client, err := um.Create(client)
+	if err != nil {
+		return err
+	}
+	session.Log.DebugMessage("New client created: %# v", client)
+
+	d.SetId(client.ClientID)
+	return resourceClientUpdate(d, NewResourceMeta{meta})
+}
+
+func resourceClientRead(d *schema.ResourceData, meta interface{}) error {
+	session := meta.(*uaaapi.Session)
+	if session == nil {
+		return fmt.Errorf("client is nil")
+	}
+
+	um := session.ClientManager()
+	id := d.Id()
+
+	client, err := um.GetClient(id)
+	if err != nil {
+		d.SetId("")
+		return err
+	}
+	session.Log.DebugMessage("Client with ID '%s' retrieved: %# v", id, client)
+
+	if false == client.HasDefaultScope() {
+		d.Set("scope", schema.NewSet(resourceStringHash, toInterface(client.Scope)))
+	}
+
+	if false == client.HasDefaultAuthorites() {
+		d.Set("authorities", schema.NewSet(resourceStringHash, toInterface(client.Authorities)))
+	}
+
+	if false == client.HasDefaultResourceIds() {
+		d.Set("resource_ids", schema.NewSet(resourceStringHash, toInterface(client.ResourceIds)))
+	}
+
+	d.Set("client_id", client.ClientID)
+	d.Set("authorized_grant_types", schema.NewSet(resourceStringHash, toInterface(client.AuthorizedGrantTypes)))
+	d.Set("redirect_uri", schema.NewSet(resourceStringHash, toInterface(client.RedirectURI)))
+	d.Set("autoapprove", schema.NewSet(resourceStringHash, toInterface(client.Autoapprove)))
+	d.Set("access_token_validity", client.AccessTokenValidity)
+	d.Set("refresh_token_validity", client.RefreshTokenValidity)
+	d.Set("allowedproviders", schema.NewSet(resourceStringHash, toInterface(client.Allowedproviders)))
+	d.Set("name", client.Name)
+	d.Set("token_salt", client.TokenSalt)
+	d.Set("createdwith", client.CreatedWith)
+	d.Set("approvals_deleted", client.ApprovalsDeleted)
+	d.Set("required_user_groups", schema.NewSet(resourceStringHash, toInterface(client.RequiredUserGroups)))
+
+	return nil
+}
+
+func resourceClientUpdate(d *schema.ResourceData, meta interface{}) error {
+	var (
+		newResource bool
+		session     *uaaapi.Session
+	)
+
+	if m, ok := meta.(NewResourceMeta); ok {
+		session = m.meta.(*uaaapi.Session)
+		newResource = true
+	} else {
+		session = meta.(*uaaapi.Session)
+		if session == nil {
+			return fmt.Errorf("client is nil")
+		}
+		newResource = false
+	}
+
+	id := d.Id()
+	um := session.ClientManager()
+
+	if !newResource {
+		u := false
+		name := getChangedValueString("name", &u, d)
+		salt := getChangedValueString("token_salt", &u, d)
+		created := getChangedValueString("createdwith", &u, d)
+		providers := getChangedValueStringList("allowedproviders", &u, d)
+		grants := getChangedValueStringList("authorized_grant_types", &u, d)
+		uris := getChangedValueStringList("redirect_uri", &u, d)
+		scope := getChangedValueStringList("scopes", &u, d)
+		resources := getChangedValueStringList("resource_ids", &u, d)
+		authorities := getChangedValueStringList("authorities", &u, d)
+		groups := getChangedValueStringList("required_user_groups", &u, d)
+		autoapprove := getChangedValueStringList("autoapprove", &u, d)
+		accestok := getChangedValueInt("access_token_validity", &u, d)
+		refreshtok := getChangedValueInt("refresh_token_validity", &u, d)
+		approval := getChangedValueBool("approvals_deleted", &u, d)
+
+		if u {
+			client := uaaapi.UAAClient{
+				ClientID:             id,
+				AuthorizedGrantTypes: *grants,
+				RedirectURI:          *uris,
+				Scope:                *scope,
+				ResourceIds:          *resources,
+				Authorities:          *authorities,
+				Autoapprove:          *autoapprove,
+				AccessTokenValidity:  *accestok,
+				RefreshTokenValidity: *refreshtok,
+				Allowedproviders:     *providers,
+				Name:                 *name,
+				TokenSalt:            *salt,
+				CreatedWith:          *created,
+				ApprovalsDeleted:     *approval,
+				RequiredUserGroups:   *groups,
+			}
+			nclient, err := um.UpdateClient(&client)
+			if err != nil {
+				return err
+			}
+			session.Log.DebugMessage("Client updated: %# v", nclient)
+		}
+
+		updateSecret, oldSecret, newSecret := getResourceChange("client_secret", d)
+		if updateSecret {
+			err := um.ChangeSecret(id, oldSecret, newSecret)
+			if err != nil {
+				return err
+			}
+			session.Log.DebugMessage("Secret for client with id '%s' updated.", id)
+		}
+	}
+
+	return nil
+}
+
+func resourceClientDelete(d *schema.ResourceData, meta interface{}) error {
+	session := meta.(*uaaapi.Session)
+	if session == nil {
+		return fmt.Errorf("client is nil")
+	}
+
+	id := d.Id()
+	um := session.ClientManager()
+	um.DeleteClient(id)
+	return nil
+}
+
+func toStrings(data interface{}) (res []string) {
+	for _, val := range data.(*schema.Set).List() {
+		res = append(res, val.(string))
+	}
+	return
+}
+
+func toInterface(data []string) (res []interface{}) {
+	for _, val := range data {
+		res = append(res, val)
+	}
+	return
+}

--- a/uaa/resource_cf_client_test.go
+++ b/uaa/resource_cf_client_test.go
@@ -1,0 +1,211 @@
+package uaa
+
+import (
+	"code.cloudfoundry.org/cli/cf/errors"
+	"fmt"
+	"github.com/hashicorp/terraform/helper/hashcode"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/terraform-providers/terraform-provider-uaa/uaa/uaaapi"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+const clientResource = `
+resource "uaa_client" "client1" {
+    client_id = "my-name"
+    authorized_grant_types = [ "client_credentials" ]
+    redirect_uri = [ "https://uaa.local.pcfdev.io/login" ]
+    client_secret = "mysecret"
+}
+`
+
+const clientResourceUpdateSecret = `
+resource "uaa_client" "client1" {
+    client_id = "my-name"
+    authorized_grant_types = [ "client_credentials" ]
+    redirect_uri = [ "https://uaa.local.pcfdev.io/login" ]
+    client_secret = "newsecret"
+}
+`
+
+const clientResourceWithoutSecret = `
+resource "uaa_client" "client2" {
+    client_id = "my-name2"
+    authorized_grant_types = [ "client_credentials" ]
+    redirect_uri = [ "https://uaa.local.pcfdev.io/login" ]
+}
+`
+
+const clientResourceWithScope = `
+resource "uaa_client" "client3" {
+    client_id = "my-name-scope"
+    scope = ["uaa.admin", "openid"]
+    authorized_grant_types = [ "client_credentials" ]
+    redirect_uri = [ "https://uaa.local.pcfdev.io/login" ]
+    client_secret = "mysecret"
+}
+`
+
+func TestAccClient_normal(t *testing.T) {
+	ref := "uaa_client.client1"
+	clientid := "my-name"
+
+	resource.Test(t,
+		resource.TestCase{
+			PreCheck:     func() { testAccPreCheck(t) },
+			Providers:    testAccProviders,
+			CheckDestroy: testAccCheckClientDestroy(clientid),
+			Steps: []resource.TestStep{
+				resource.TestStep{
+					Config: clientResource,
+					Check: resource.ComposeTestCheckFunc(
+						testAccCheckClientExists(ref),
+						testAccCheckValidSecret(ref, "mysecret"),
+						resource.TestCheckResourceAttr(ref, "client_id", clientid),
+						testCheckResourceSet(ref, "authorized_grant_types", []string{"client_credentials"}),
+						testCheckResourceSet(ref, "redirect_uri", []string{"https://uaa.local.pcfdev.io/login"}),
+					),
+				},
+				resource.TestStep{
+					Config: clientResourceUpdateSecret,
+					Check: resource.ComposeTestCheckFunc(
+						testAccCheckClientExists(ref),
+						testAccCheckValidSecret(ref, "newsecret"),
+						resource.TestCheckResourceAttr(ref, "client_id", clientid),
+						testCheckResourceSet(ref, "authorized_grant_types", []string{"client_credentials"}),
+						testCheckResourceSet(ref, "redirect_uri", []string{"https://uaa.local.pcfdev.io/login"}),
+					),
+				},
+			},
+		})
+}
+
+func TestAccClient_scope(t *testing.T) {
+	ref := "uaa_client.client3"
+	clientid := "my-name-scope"
+
+	resource.Test(t,
+		resource.TestCase{
+			PreCheck:     func() { testAccPreCheck(t) },
+			Providers:    testAccProviders,
+			CheckDestroy: testAccCheckClientDestroy(clientid),
+			Steps: []resource.TestStep{
+				resource.TestStep{
+					Config: clientResourceWithScope,
+					Check: resource.ComposeTestCheckFunc(
+						testAccCheckClientExists(ref),
+						testAccCheckValidSecret(ref, "mysecret"),
+						resource.TestCheckResourceAttr(ref, "client_id", clientid),
+						testCheckResourceSet(ref, "authorized_grant_types", []string{"client_credentials"}),
+						testCheckResourceSet(ref, "redirect_uri", []string{"https://uaa.local.pcfdev.io/login"}),
+						testCheckResourceSet(ref, "scope", []string{"uaa.admin", "openid"}),
+					),
+				},
+			},
+		})
+}
+
+func TestAccClient_createError(t *testing.T) {
+	clientid := "my-name2"
+
+	resource.Test(t,
+		resource.TestCase{
+			PreCheck:     func() { testAccPreCheck(t) },
+			Providers:    testAccProviders,
+			CheckDestroy: testAccCheckClientDestroy(clientid),
+			Steps: []resource.TestStep{
+				resource.TestStep{
+					Config:      clientResourceWithoutSecret,
+					ExpectError: regexp.MustCompile(".*Client secret is required for client_credentials.*"),
+				},
+			},
+		})
+}
+
+func testAccCheckValidSecret(resource, secret string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		session := testAccProvider.Meta().(*uaaapi.Session)
+		rs, ok := s.RootModule().Resources[resource]
+		if !ok {
+			return fmt.Errorf("client '%s' not found in terraform state", resource)
+		}
+
+		id := rs.Primary.ID
+		um := session.ClientManager()
+
+		data := url.Values{
+			"client_id":     {id},
+			"client_secret": {secret},
+			"grant_type":    {"client_credentials"},
+			"token_format":  {"opaque"},
+			"response_type": {"token"},
+		}
+		req, err := http.NewRequest("POST",
+			fmt.Sprintf("%s/oauth/token", um.UaaEndPoint()),
+			strings.NewReader(data.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.Header.Set("Accept", "application/json")
+
+		client := &http.Client{}
+		res, err := client.Do(req)
+		if err != nil || res.StatusCode != 200 {
+			return fmt.Errorf("client '%s' has invalid secret", id)
+		}
+		return nil
+	}
+}
+
+func testAccCheckClientExists(resource string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		session := testAccProvider.Meta().(*uaaapi.Session)
+		rs, ok := s.RootModule().Resources[resource]
+		if !ok {
+			return fmt.Errorf("client '%s' not found in terraform state", resource)
+		}
+		session.Log.DebugMessage("terraform state for resource '%s': %# v", resource, rs)
+
+		id := rs.Primary.ID
+		um := session.ClientManager()
+
+		// check client exists
+		_, err := um.GetClient(id)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+}
+
+func testCheckResourceSet(ref string, attr string, values []string) resource.TestCheckFunc {
+	var lTests []resource.TestCheckFunc
+	lKey := fmt.Sprintf("%s.#", attr)
+	lVal := fmt.Sprintf("%d", len(values))
+	lTests = append(lTests, resource.TestCheckResourceAttr(ref, lKey, lVal))
+
+	for _, cVal := range values {
+		lKey = fmt.Sprintf("%s.%d", attr, hashcode.String(cVal))
+		lTests = append(lTests, resource.TestCheckResourceAttr(ref, lKey, cVal))
+	}
+	return resource.ComposeTestCheckFunc(lTests...)
+}
+
+func testAccCheckClientDestroy(id string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		session := testAccProvider.Meta().(*uaaapi.Session)
+		um := session.ClientManager()
+		if _, err := um.FindByClientID(id); err != nil {
+			switch err.(type) {
+			case *errors.ModelNotFoundError:
+				return nil
+			default:
+				return err
+			}
+		}
+		return fmt.Errorf("client with id '%s' still exists in cloud foundry", id)
+	}
+}

--- a/uaa/uaaapi/auth_manager.go
+++ b/uaa/uaaapi/auth_manager.go
@@ -148,8 +148,8 @@ func (tm *AuthManager) Authenticate(credentials map[string]string) error {
 	return nil
 }
 
-// getClientToken -
-func (tm *AuthManager) getClientToken(clientID, clientSecret string) (clientToken string, err error) {
+// GetClientToken -
+func (tm *AuthManager) GetClientToken(clientID, clientSecret string) (clientToken string, err error) {
 
 	data := url.Values{
 		"grant_type": {"client_credentials"},

--- a/uaa/uaaapi/client_manager.go
+++ b/uaa/uaaapi/client_manager.go
@@ -1,0 +1,209 @@
+package uaaapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"code.cloudfoundry.org/cli/cf/configuration/coreconfig"
+	"code.cloudfoundry.org/cli/cf/errors"
+	"code.cloudfoundry.org/cli/cf/net"
+)
+
+// ClientManager -
+type ClientManager struct {
+	log        *Logger
+	config     coreconfig.Reader
+	uaaGateway net.Gateway
+}
+
+// ClientSecret         string   `json:"client_secret,omitempty"`
+
+// UAAClient -
+type UAAClient struct {
+	ClientID             string   `json:"client_id,omitempty"`
+	ClientSecret         string   `json:"client_secret,omitempty"`
+	AuthorizedGrantTypes []string `json:"authorized_grant_types,omitempty"`
+	RedirectURI          []string `json:"redirect_uri,omitempty"`
+	Scope                []string `json:"scope,omitempty"`
+	ResourceIds          []string `json:"resource_ids,omitempty"`
+	Authorities          []string `json:"authorities,omitempty"`
+	Autoapprove          []string `json:"autoapprove,omitempty"`
+	AccessTokenValidity  int      `json:"access_token_validity,omitempty"`
+	RefreshTokenValidity int      `json:"refresh_token_validity,omitempty"`
+	Allowedproviders     []string `json:"allowedproviders,omitempty"`
+	Name                 string   `json:"name,omitempty"`
+	TokenSalt            string   `json:"token_salt,omitempty"`
+	CreatedWith          string   `json:"createdwith,omitempty"`
+	ApprovalsDeleted     bool     `json:"approvals_deleted,omitempty"`
+	RequiredUserGroups   []string `json:"required_user_groups,omitempty"`
+	LastModified         int64    `json:"lastModified,omitempty"`
+}
+
+// UAAClientResourceList -
+type UAAClientResourceList struct {
+	Resources []UAAClient `json:"resources"`
+}
+
+func (c *UAAClient) HasDefaultScope() bool {
+	return len(c.Scope) == 1 && c.Scope[0] == "uaa.none"
+}
+
+func (c *UAAClient) HasDefaultAuthorites() bool {
+	return len(c.Authorities) == 1 && c.Authorities[0] == "uaa.none"
+}
+
+func (c *UAAClient) HasDefaultResourceIds() bool {
+	return len(c.ResourceIds) == 1 && c.ResourceIds[0] == "none"
+}
+
+// NewClientManager -
+func newClientManager(config coreconfig.Reader, uaaGateway net.Gateway, logger *Logger) (cm *ClientManager, err error) {
+	cm = &ClientManager{
+		log:        logger,
+		config:     config,
+		uaaGateway: uaaGateway,
+	}
+	return
+}
+
+// GetClient -
+func (cm *ClientManager) GetClient(id string) (client *UAAClient, err error) {
+	uaaEndpoint := cm.config.UaaEndpoint()
+	if len(uaaEndpoint) == 0 {
+		err = errors.New("UAA endpoint missing from config file")
+		return
+	}
+
+	client = &UAAClient{}
+	err = cm.uaaGateway.GetResource(
+		fmt.Sprintf("%s/oauth/clients/%s", uaaEndpoint, id),
+		client)
+	return
+}
+
+func (cm *ClientManager) UaaEndPoint() string {
+	return cm.config.UaaEndpoint()
+}
+
+// CreateClient -
+func (cm *ClientManager) Create(nCli UAAClient) (client UAAClient, err error) {
+	uaaEndpoint := cm.config.UaaEndpoint()
+	if len(uaaEndpoint) == 0 {
+		err = errors.New("UAA endpoint missing from config file")
+		return
+	}
+
+	body, err := json.Marshal(nCli)
+	if err != nil {
+		return
+	}
+
+	client = nCli
+	err = cm.uaaGateway.CreateResource(uaaEndpoint, "/oauth/clients", bytes.NewReader(body), &client)
+	switch httpErr := err.(type) {
+	case errors.HTTPError:
+		if httpErr.StatusCode() == http.StatusConflict {
+			err = errors.NewModelAlreadyExistsError("client", nCli.ClientID)
+		}
+	}
+	return
+}
+
+// UpdateClient -
+func (cm *ClientManager) UpdateClient(nCli *UAAClient) (client UAAClient, err error) {
+	uaaEndpoint := cm.config.UaaEndpoint()
+	if len(uaaEndpoint) == 0 {
+		err = errors.New("UAA endpoint missing from config file")
+		return
+	}
+
+	body, err := json.Marshal(nCli)
+	if err != nil {
+		return
+	}
+
+	request, err := cm.uaaGateway.NewRequest("PUT",
+		fmt.Sprintf("%s/oauth/clients/%s", uaaEndpoint, nCli.ClientID),
+		cm.config.AccessToken(), bytes.NewReader(body))
+	if err != nil {
+		return
+	}
+
+	client = *nCli
+	_, err = cm.uaaGateway.PerformRequestForJSONResponse(request, client)
+	return
+}
+
+// DeleteClient -
+func (cm *ClientManager) DeleteClient(id string) (err error) {
+	uaaEndpoint := cm.config.UaaEndpoint()
+	if len(uaaEndpoint) == 0 {
+		err = errors.New("UAA endpoint missing from config file")
+		return
+	}
+	err = cm.uaaGateway.DeleteResource(uaaEndpoint, fmt.Sprintf("/oauth/clients/%s", id))
+	return
+}
+
+// ChangePassword -
+func (cm *ClientManager) ChangeSecret(id, oldSecret, newSecret string) (err error) {
+	uaaEndpoint := cm.config.UaaEndpoint()
+	if len(uaaEndpoint) == 0 {
+		err = errors.New("UAA endpoint missing from config file")
+		return
+	}
+
+	data := map[string]string{
+		"secret": newSecret,
+	}
+
+	if len(oldSecret) != 0 {
+		data["oldSecret"] = oldSecret
+	}
+
+	body, err := json.Marshal(data)
+	if err != nil {
+		return
+	}
+
+	request, err := cm.uaaGateway.NewRequest("PUT",
+		uaaEndpoint+fmt.Sprintf("/oauth/clients/%s/secret", id),
+		cm.config.AccessToken(), bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+
+	response := make(map[string]interface{})
+	_, err = cm.uaaGateway.PerformRequestForJSONResponse(request, response)
+	if err != nil {
+		return err
+	}
+	return
+}
+
+// FindByClientID -
+func (cm *ClientManager) FindByClientID(clientID string) (client UAAClient, err error) {
+	uaaEndpoint := cm.config.UaaEndpoint()
+	if len(uaaEndpoint) == 0 {
+		err = errors.New("UAA endpoint missing from config file")
+		return
+	}
+
+	filter := url.QueryEscape(fmt.Sprintf(`client_id Eq "%s"`, clientID))
+	path := fmt.Sprintf("%s/oauth/clients?filter=%s", uaaEndpoint, filter)
+
+	clientResourceList := &UAAClientResourceList{}
+	err = cm.uaaGateway.GetResource(path, clientResourceList)
+
+	if err == nil {
+		if len(clientResourceList.Resources) > 0 {
+			client = clientResourceList.Resources[0]
+		} else {
+			err = errors.NewModelNotFoundError("Client", clientID)
+		}
+	}
+	return
+}

--- a/uaa/uaaapi/session.go
+++ b/uaa/uaaapi/session.go
@@ -85,7 +85,7 @@ func NewSession(
 		return nil, err
 	}
 
-	if s.userManager.clientToken, err = s.authManager.getClientToken(uaaClientID, uaaClientSecret); err == nil {
+	if s.userManager.clientToken, err = s.authManager.GetClientToken(uaaClientID, uaaClientSecret); err == nil {
 		err = s.userManager.loadGroups()
 	}
 
@@ -100,6 +100,11 @@ func (s *Session) UserManager() *UserManager {
 // UserManager -
 func (s *Session) ClientManager() *ClientManager {
 	return s.clientManager
+}
+
+// AuthManager -
+func (s *Session) AuthManager() *AuthManager {
+	return s.authManager
 }
 
 // noopPersistor - No Op Persistor for CF CLI session

--- a/uaa/uaaapi/session.go
+++ b/uaa/uaaapi/session.go
@@ -24,8 +24,9 @@ type Session struct {
 	refresher  coreconfig.APIConfigRefresher
 	uaaGateway net.Gateway
 
-	authManager *AuthManager
-	userManager *UserManager
+	authManager   *AuthManager
+	userManager   *UserManager
+	clientManager *ClientManager
 
 	// Used for direct endpoint calls
 	httpClient *http.Client
@@ -79,15 +80,26 @@ func NewSession(
 		return nil, err
 	}
 
+	s.clientManager, err = newClientManager(s.config, s.uaaGateway, s.Log)
+	if err != nil {
+		return nil, err
+	}
+
 	if s.userManager.clientToken, err = s.authManager.getClientToken(uaaClientID, uaaClientSecret); err == nil {
 		err = s.userManager.loadGroups()
 	}
+
 	return
 }
 
 // UserManager -
 func (s *Session) UserManager() *UserManager {
 	return s.userManager
+}
+
+// UserManager -
+func (s *Session) ClientManager() *ClientManager {
+	return s.clientManager
 }
 
 // noopPersistor - No Op Persistor for CF CLI session

--- a/uaa/utils_terraform.go
+++ b/uaa/utils_terraform.go
@@ -78,6 +78,26 @@ func getChangedValueIntList(key string, updated *bool, d *schema.ResourceData) *
 	return nil
 }
 
+// getChangedValueStringList
+func getChangedValueStringList(key string, updated *bool, d *schema.ResourceData) *[]string {
+	var a []interface{}
+
+	if d.HasChange(key) {
+		a = d.Get(key).(*schema.Set).List()
+		*updated = *updated || true
+	} else if v, ok := d.GetOk(key); ok {
+		a = v.(*schema.Set).List()
+	}
+	if a != nil {
+		aa := []string{}
+		for _, vv := range a {
+			aa = append(aa, vv.(string))
+		}
+		return &aa
+	}
+	return nil
+}
+
 // getChangedValueMap -
 func getChangedValueMap(key string, updated *bool, d *schema.ResourceData) *map[string]interface{} {
 

--- a/website/docs/d/client.html.markdown
+++ b/website/docs/d/client.html.markdown
@@ -1,0 +1,48 @@
+---
+layout: "uaa"
+page_title: "Cloud Foundry UAA: uaa_client"
+sidebar_current: "docs-uaa-datasource-client"
+description: |-
+  Get information on a Cloud Foundry UAA Client.
+---
+
+# uaa\_client
+
+Gets information on a Cloud Foundry UAA Client.
+
+## Example Usage
+
+The following example looks up a client named 'myclient'.
+
+```
+data "uaa_client" "myclient" {
+    client_id = "myclient"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `client_id` - (Required) The client_id of the client to look up
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The GUID of the client
+* `client_id` - Client identifier, unique within identity zone.
+* `authorized_grant_types` - List of grant types that can be used to obtain a token with this client.
+* `redirect_uri` - Allowed URI pattern for redirect during authorization.
+* `scope` - Scopes allowed for the client.
+* `resource_ids` - Resources the client is allowed access to.
+* `authorities` - Scopes which the client is able to grant when creating a client.
+* `autoapprove` - Scopes that do not require user approval.
+* `access_token_validity` - time in seconds to access token expiration after it is issued.
+* `refresh_token_validity` - time in seconds to refresh token expiration after it is issued.
+* `allowedproviders` - A list of origin keys (alias) for identity providers the client is limited to.
+* `name` - A human readable name for the client.
+* `createdwith` - What scope the bearer token had when client was created.
+* `token_salt` - A random string used to generate the client's revokation key.
+* `approvals_deleted` - Were the approvals deleted for the client, and an audit event sent.
+* `required_user_groups` - A list of group names.

--- a/website/docs/r/client.html.markdown
+++ b/website/docs/r/client.html.markdown
@@ -1,0 +1,52 @@
+---
+layout: "uaa"
+page_title: "Cloud Foundry UAA: uaa_client"
+sidebar_current: "docs-uaa-resource-client"
+description: |-
+  Provides a Cloud Foundry UAA Client resource.
+---
+
+# uaa\_client
+
+Provides a resource for managing Cloud Foundry UUA clients.
+
+## Example Usage
+
+The following example creates a client.
+
+```
+resource "uaa_client" "admin-service-client" {
+    client_id = "admin-client"
+    client_secret = "mysecret"
+    authorized_grant_types = [ "client_credentials" ]
+    redirect_uri = [ "https://uaa.local.pcfdev.io/login" ]
+    scope = ["uaa.admin", "openid"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `client_id` - (Required) Client identifier, unique within identity zone.
+* `authorized_grant_types` - (Required) List of grant types that can be used to obtain a token with this client. Can include authorization_code, password, implicit, and/or client_credentials.
+* `redirect_uri` - (Required) Allowed URI pattern for redirect during authorization. Wildcard patterns can be specified using the Ant-style pattern.
+* `scope` - (Optional) Scopes allowed for the client.
+* `resource_ids` - (Optional) Resources the client is allowed access to.
+* `authorities` - (Optional) Scopes which the client is able to grant when creating a client.
+* `autoapprove` - (Optional) Scopes that do not require user approval.
+* `access_token_validity` - (Optional) time in seconds to access token expiration after it is issued.
+* `refresh_token_validity` - (Optional) time in seconds to refresh token expiration after it is issued.
+* `allowedproviders` - (Optional) A list of origin keys (alias) for identity providers the client is limited to.
+* `name` - (Optional) A human readable name for the client.
+* `token_salt` - (Optional) A random string used to generate the client's revokation key. Change this value to revoke all active tokens for the client.
+* `createdwith` - (Optional) What scope the bearer token had when client was created.
+* `approvals_deleted` - (Optional) Were the approvals deleted for the client, and an audit event sent.
+* `required_user_groups` - (Optional) A list of group names.
+* `client_secret` - (Required if the client allows authorization_code or client_credentials grant type) A secret string used for authenticating as this client.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The GUID of the Client

--- a/website/uaa.erb
+++ b/website/uaa.erb
@@ -16,7 +16,10 @@
 				<a href="#">Data Sources</a>
 				<ul class="nav nav-visible">
 					<li<%= sidebar_current("docs-uaa-datasource-user") %>>
-					<a href="/docs/providers/uaa/d/user.html">cf_user</a>
+					<a href="/docs/providers/uaa/d/user.html">uaa_user</a>
+					</li>
+					<li<%= sidebar_current("docs-uaa-datasource-client") %>>
+					<a href="/docs/providers/uaa/d/client.html">uaa_client</a>
 					</li>
 				</ul>
 			</li>
@@ -26,6 +29,11 @@
 				<ul class="nav nav-visible">
 					<li<%= sidebar_current("docs-uaa-resource-user") %>>
 					<a href="/docs/providers/uaa/r/user.html">uaa_user</a>
+					</li>
+				</ul>
+				<ul class="nav nav-visible">
+					<li<%= sidebar_current("docs-uaa-resource-client") %>>
+					<a href="/docs/providers/uaa/r/user.html">uaa_client</a>
 					</li>
 				</ul>
 			</li>


### PR DESCRIPTION
This PR adds uaa clients management to the provider.

### Resource

```
resource "uaa_client" "admin-service-client" {
    client_id = "admin-client"
    client_secret = "mysecret"
    authorized_grant_types = [ "client_credentials" ]
    redirect_uri = [ "https://uaa.local.pcfdev.io/login" ]
    scope = ["uaa.admin", "openid"]
}
```
Arguments:
* `client_id` - (Required) Client identifier, unique within identity zone.
* `authorized_grant_types` - (Required) List of grant types that can be used to obtain a token with this client. Can include authorization_code, password, implicit, and/or client_credentials.
* `redirect_uri` - (Required) Allowed URI pattern for redirect during authorization. Wildcard patterns can be specified using the Ant-style pattern.
* `scope` - (Optional) Scopes allowed for the client.
* `resource_ids` - (Optional) Resources the client is allowed access to.
* `authorities` - (Optional) Scopes which the client is able to grant when creating a client.
* `autoapprove` - (Optional) Scopes that do not require user approval.
* `access_token_validity` - (Optional) time in seconds to access token expiration after it is issued.
* `refresh_token_validity` - (Optional) time in seconds to refresh token expiration after it is issued.
* `allowedproviders` - (Optional) A list of origin keys (alias) for identity providers the client is limited to.
* `name` - (Optional) A human readable name for the client.
* `token_salt` - (Optional) A random string used to generate the client's revokation key. Change this value to revoke all active tokens for the client.
* `createdwith` - (Optional) What scope the bearer token had when client was created.
* `approvals_deleted` - (Optional) Were the approvals deleted for the client, and an audit event sent.
* `required_user_groups` - (Optional) A list of group names.
* `client_secret` - (Required if the client allows authorization_code or client_credentials grant type) A secret string used for authenticating as this client.



### Data

```
data "uaa_client" "myclient" {
    client_id = "myclient"
}
```
Exported attributes:

* `id` - The GUID of the client
* `client_id` - Client identifier, unique within identity zone.
* `authorized_grant_types` - List of grant types that can be used to obtain a token with this client.
* `redirect_uri` - Allowed URI pattern for redirect during authorization.
* `scope` - Scopes allowed for the client.
* `resource_ids` - Resources the client is allowed access to.
* `authorities` - Scopes which the client is able to grant when creating a client.
* `autoapprove` - Scopes that do not require user approval.
* `access_token_validity` - time in seconds to access token expiration after it is issued.
* `refresh_token_validity` - time in seconds to refresh token expiration after it is issued.
* `allowedproviders` - A list of origin keys (alias) for identity providers the client is limited to.
* `name` - A human readable name for the client.
* `createdwith` - What scope the bearer token had when client was created.
* `token_salt` - A random string used to generate the client's revokation key.
* `approvals_deleted` - Were the approvals deleted for the client, and an audit event sent.
* `required_user_groups` - A list of group names.


 